### PR TITLE
Add slash in url when use simple_html api type

### DIFF
--- a/pip_upgrader/packages_status_detector.py
+++ b/pip_upgrader/packages_status_detector.py
@@ -91,11 +91,11 @@ class PackagesStatusDetector(object):
 
         if index_url.endswith('/simple/'):
             self.PYPI_API_TYPE = 'simple_html'
-            return urljoin(index_url, '{package}')
+            return urljoin(index_url, '{package}/')
 
         if index_url.endswith('/+simple/'):
             self.PYPI_API_TYPE = 'simple_html'
-            return urljoin(index_url, '{package}')
+            return urljoin(index_url, '{package}/')
 
         if '/pypi/' in index_url:
             base_url = index_url.split('/pypi/')[0]


### PR DESCRIPTION
When I use aliyun pip mirror, I get following error:
```
Setting API url to https://mirrors.aliyun.com/pypi/simple/{package} as found in /home/deepin/.pip/pip.conf. Use --default-index-url to use pypi default index
Error while parsing package bumpversion==0.5.3 (skipping). 
Exception:  HTTPConnectionPool(host='pub.mirrors.aliyun.com', port=80): Max retries exceeded with url: /pypi/simple/bumpversion/ (Caused by NewConnectionError('<requests.packages.urllib3.connection.HTTPConnection object at 0x7f56e9af2390>: Failed to establish a new connection: [Errno -2] Name or service not known',))
```

My mirror config
```
[global]
index-url = https://mirrors.aliyun.com/pypi/simple
trusted-host = mirrors.aliyun.com
```

aliyun mirror will redirect  [https://mirrors.aliyun.com/pypi/simple/twine](https://mirrors.aliyun.com/pypi/simple/twine)  to `http://pub.mirrors.aliyun.com/pypi/simple/twine/`, it a wrong address. 

After adding a slash in url, it works fine.  [https://mirrors.aliyun.com/pypi/simple/twine/](https://mirrors.aliyun.com/pypi/simple/twine/) will get right html content.

I think a package meaning a directory and should end with slash in `simple_html` api type.

@simion  Please review this PR.