### PR TITLE
include LICENSE file in distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 exclude .gitignore
 exclude .coverage
 exclude .travis.yml
+include LICENSE
 include README.rst
 include setup.cfg
 prune .cache

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,6 @@ universal=1
 [tool:pytest]
 addopts = --cov=pip_upgrader --cov-report=term-missing -s --pep8
 pep8maxlinelength = 120
+
+[metadata]
+license-file = LICENSE


### PR DESCRIPTION
Redistributions of your source code are supposed to include the `LICENSE` text under the terms of your license, but your distributions currently don't – this makes it harder for everyone to follow the license. :)

The `MANIFEST.in` file makes sure that `LICENSE` ends up in the `.tar.gz` source files from `sdist`, and the `setup.cfg` setting tells wheels about it.