### PR TITLE
Style - Add content type of the readme in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
     setup_requires=['setuptools_scm'],
     description='An interactive pip requirements upgrader. It also updates the version in your requirements.txt file.',
     long_description=long_description,
+    long_description_content_type="text/x-rst",
     url='https://github.com/simion/pip-upgrader',
     author='Simion Baws',
     author_email='simion.agv@gmail.com',


### PR DESCRIPTION
This permit to have RST formatting for the readme on pypi.

See : https://packaging.python.org/guides/making-a-pypi-friendly-readme/#including-your-readme-in-your-package-s-metadata
and https://packaging.python.org/specifications/core-metadata/#description-content-type-optional