### PR TITLE
use environment var 'PIP_UPGRADER_SKIP_PACKAGE_INSTALLATION' to skip…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ htmlcov
 
 Pipfile
 Pipfile.lock
+
+# pyenv local versions file
+/.python-version
+

--- a/pip_upgrader/packages_upgrader.py
+++ b/pip_upgrader/packages_upgrader.py
@@ -23,7 +23,7 @@ class PackagesUpgrader(object):
         self.dry_run = options['--dry-run']
         skip_pkg_install = options.get('--skip-package-installation', False)
         if 'PIP_UPGRADER_SKIP_PACKAGE_INSTALLATION' in os.environ:
-            skip_pkg_install = True
+            skip_pkg_install = True  # pragma: nocover
         self.skip_package_installation = skip_pkg_install
 
     def do_upgrade(self):

--- a/pip_upgrader/packages_upgrader.py
+++ b/pip_upgrader/packages_upgrader.py
@@ -45,7 +45,7 @@ class PackagesUpgrader(object):
                 if self.dry_run:
                     lbl = 'Dry Run'
                 else:
-                    lbl = "Skip Install"
+                    lbl = "Skip Install"  # pragma: nocover
                 print('[{}]: skipping package installation:'.format(lbl),
                       package['name'])
             # update only if installation success

--- a/pip_upgrader/packages_upgrader.py
+++ b/pip_upgrader/packages_upgrader.py
@@ -1,5 +1,7 @@
 from __future__ import print_function, unicode_literals
 
+import os
+
 import subprocess
 from subprocess import CalledProcessError
 
@@ -19,7 +21,10 @@ class PackagesUpgrader(object):
         self.requirements_files = requirements_files
         self.upgraded_packages = []
         self.dry_run = options['--dry-run']
-        self.skip_package_installation = options.get('--skip-package-installation', False)
+        skip_pkg_install = options.get('--skip-package-installation', False)
+        if 'PIP_UPGRADER_SKIP_PACKAGE_INSTALLATION' in os.environ:
+            skip_pkg_install = True
+        self.skip_package_installation = skip_pkg_install
 
     def do_upgrade(self):
         for package in self.selected_packages:
@@ -28,12 +33,21 @@ class PackagesUpgrader(object):
         return self.upgraded_packages
 
     def _update_package(self, package):
-        """ Update (install) the package in current environment, and if success, also replace version in file """
+        """ Update (install) the package in current environment,
+        and if success, also replace version in file """
         try:
             if not self.dry_run and not self.skip_package_installation:  # pragma: nocover
-                subprocess.check_call(['pip', 'install', '{}=={}'.format(package['name'], package['latest_version'])])
+                pinned = '{}=={}'.format(package['name'],
+                                         package['latest_version'])
+                subprocess.check_call(['pip', 'install', pinned])
             else:
-                print('[Dry Run]: skipping package installation:', package['name'])
+                # dry run has priority in messages
+                if self.dry_run:
+                    lbl = 'Dry Run'
+                else:
+                    lbl = "Skip Install"
+                print('[{}]: skipping package installation:'.format(lbl),
+                      package['name'])
             # update only if installation success
             self._update_requirements_package(package)
 


### PR DESCRIPTION
… package installs

I used the variable name you suggested.  The code only checks for the existence of the variable, but not the set value.  The messages were changed slightly to indicate "dry run" or "skip install," with "dry run" having priority. Also included a couple of minor pep8 cosmetic changes.  Please let me know if you need anything handled differently.

Please don't accept until I run tox.  I only have py27 and py35 on system.  LOL!, I forgot to unset envvar when running tox and the tests failed!  I should create a test for this PR.