### PR TITLE
Added support for package>=version via option --check-greater-equal

### DIFF
--- a/pip_upgrader/cli.py
+++ b/pip_upgrader/cli.py
@@ -2,13 +2,14 @@
 pip-upgrade
 
 Usage:
-  pip-upgrade [<requirements_file>] ... [--prerelease] [-p=<package>...] [--dry-run] [--skip-virtualenv-check] [--skip-package-installation] [--use-default-index]
+  pip-upgrade [<requirements_file>] ... [--prerelease] [-p=<package>...] [--dry-run] [--check-greater-equal] [--skip-virtualenv-check] [--skip-package-installation] [--use-default-index]
 
 Arguments:
     requirements_file             The requirement FILE, or WILDCARD PATH to multiple files.
     --prerelease                  Include prerelease versions for upgrade, when querying pypi repositories.
     -p <package>                  Pre-choose which packages tp upgrade. Skips any prompt. You can also use regular expressions to filter packages to upgrade.
     --dry-run                     Simulates the upgrade, but does not execute the actual upgrade.
+    --check-greater-equal         Also checks packages with minimum version pinned (package>=version).
     --skip-package-installation   Only upgrade the version in requirements files, don't install the new package.
     --skip-virtualenv-check       Disable virtualenv check. Allows installing the new packages outside the virtualenv.
     --use-default-index           Skip searching for custom index-url in pip configuration file(s).
@@ -67,7 +68,7 @@ def main():
 
         # 3. query pypi API, see which package has a newer version vs the one in requirements (or current env)
         packages_status_map = PackagesStatusDetector(
-            packages, options.get('--use-default-index')).detect_available_upgrades(options)
+            packages, options).detect_available_upgrades(options)
 
         # 4. [optionally], show interactive screen when user can choose which packages to upgrade
         selected_packages = PackageInteractiveSelector(packages_status_map, options).get_packages()

--- a/pip_upgrader/packages_upgrader.py
+++ b/pip_upgrader/packages_upgrader.py
@@ -13,12 +13,14 @@ class PackagesUpgrader(object):
     requirements_files = None
     upgraded_packages = None
     dry_run = False
+    check_gte = False
 
     def __init__(self, selected_packages, requirements_files, options):
         self.selected_packages = selected_packages
         self.requirements_files = requirements_files
         self.upgraded_packages = []
         self.dry_run = options['--dry-run']
+        self.check_gte = options['--check-greater-equal']
         skip_pkg_install = options.get('--skip-package-installation', False)
         if 'PIP_UPGRADER_SKIP_PACKAGE_INSTALLATION' in os.environ:
             skip_pkg_install = True  # pragma: nocover
@@ -76,15 +78,16 @@ class PackagesUpgrader(object):
 
     def _maybe_update_line_package(self, line, package):
         original_line = line
-        pattern = r'\b{package}(?:\[\w*\])?=={old_version}\b'.format(
-            package=re.escape(package['name']),
-            old_version=re.escape(str(package['current_version'])))
+        pin_type = r'[>=]=' if self.check_gte else '=='
 
-        if re.search(pattern, line, flags=re.IGNORECASE):
-            line = line.replace(
-                '=={}'.format(package['current_version']),
-                '=={}'.format(package['latest_version'])
-            )
+        pattern = r'\b({package}(?:\[\w*\])?{pin_type}){old_version}\b'.format(
+            package=re.escape(package['name']),
+            old_version=re.escape(str(package['current_version'])),
+            pin_type=pin_type
+        )
+
+        repl = r'\g<1>{}'.format(package['latest_version'])
+        line = re.sub(pattern, repl, line)
 
         if line != original_line:
             self.upgraded_packages.append(package)

--- a/pip_upgrader/packages_upgrader.py
+++ b/pip_upgrader/packages_upgrader.py
@@ -80,9 +80,8 @@ class PackagesUpgrader(object):
         original_line = line
         pin_type = r'[>=]=' if self.check_gte else '=='
 
-        pattern = r'\b({package}(?:\[\w*\])?{pin_type}){old_version}\b'.format(
+        pattern = r'\b({package}(?:\[\w*\])?{pin_type})[a-zA-Z0-9\.]+\b'.format(
             package=re.escape(package['name']),
-            old_version=re.escape(str(package['current_version'])),
             pin_type=pin_type
         )
 


### PR DESCRIPTION
I added the option to also upgrade packages where there is a minimum version required, e.g., `package>=version`.
This is not the default behavior in this implementation, but can be activated via `--check-greater-equal` command line parameter.