### PR TITLE
Avoid upgrade flag override for multiple versions

### DIFF
--- a/pip_upgrader/packages_status_detector.py
+++ b/pip_upgrader/packages_status_detector.py
@@ -142,6 +142,11 @@ class PackagesStatusDetector(object):
                         print('up to date: {}'.format(current_version))
                     sys.stdout.flush()
 
+                    old_status = self.packages_status_map.get(package_name, None)
+
+                    if old_status is not None and old_status["upgrade_available"]:
+                        continue
+
                     self.packages_status_map[package_name] = package_status
             except Exception as e:  # noqa  # pragma: nocover
                 print('Error while parsing package {} (skipping). \nException: '.format(package), e)


### PR DESCRIPTION
It happens when there are multiple versions of one package, usually when the script receives multiple requirements files.

In this case, I changed the behavior to no override this flag and change the version on all files (even when already on latest version).