### PR TITLE
Update __init__.py

### DIFF
--- a/pip_upgrader/__init__.py
+++ b/pip_upgrader/__init__.py
@@ -1,6 +1,7 @@
-import pkg_resources
+from importlib.metadata import version 
 
 try:
-    __version__ = pkg_resources.get_distribution('pip_upgrader').version
+    __version__ = version('pip_upgrader')
 except Exception:  # pragma: nocover
     __version__ = 'unknown'
+ 


### PR DESCRIPTION
Minimal change to enable installation on Python 3.11 and 3.12 by replacing the deprecated pkg_resources dependency.