### PR TITLE
Remove file extension check

### DIFF
--- a/pip_upgrader/requirements_detector.py
+++ b/pip_upgrader/requirements_detector.py
@@ -44,8 +44,7 @@ class RequirementsDetector(object):
 
     @staticmethod
     def _is_valid_requirements_file(filename):
-        extension_ok = filename.endswith('txt') or filename.endswith('pip')
-        return extension_ok and os.path.isfile(filename) and mimetypes.guess_type(filename)[0] in ['text/plain', None]
+        return os.path.isfile(filename) and mimetypes.guess_type(filename)[0] in ['text/plain', None]
 
     def _check_inclusions_recursively(self):
         for filename in self.filenames:


### PR DESCRIPTION
The extension check causes more issues than it solves.

The remaining protections are sufficient:
- checking for file existance
- checking mime type
- checking for predefined names in auto-detect mode

Furthermore, when explicitly passing a file (either via arg or via inclusion), users should be free to choose whatever extension suits them.

Fixes #52