### PR TITLE
Fix --skip exact-name matching and invalid regex handling

### DIFF
--- a/pip_upgrader/packages_interactive_selector.py
+++ b/pip_upgrader/packages_interactive_selector.py
@@ -24,14 +24,23 @@ class PackageInteractiveSelector(object):
         self.selected_packages = []
         self.packages_for_upgrade = {}
 
+        # Compile --skip patterns upfront; plain names match exactly, regex patterns
+        # must also match the full name (use '.*django.*' to match substrings).
+        skip_patterns = []
+        for s in (options.get('--skip') or []):
+            pat = s.lower().strip()
+            try:
+                skip_patterns.append(re.compile(pat))
+            except re.error as exc:
+                raise SystemExit('Invalid --skip pattern {!r}: {}'.format(pat, exc)) from exc
+
         # map with index number, for later choosing
         i = 1
-        skip_patterns = [s.lower().strip() for s in (options.get('--skip') or [])]
         skipped_names = []
         for package in packages_map.values():
             if package['upgrade_available']:
                 name = package['name'].lower().strip()
-                if any(re.fullmatch(pat, name) or re.search(pat, name) for pat in skip_patterns):
+                if any(p.fullmatch(name) for p in skip_patterns):
                     skipped_names.append(package['name'])
                     continue
                 self.packages_for_upgrade[i] = package.copy()

--- a/pip_upgrader/packages_interactive_selector.py
+++ b/pip_upgrader/packages_interactive_selector.py
@@ -27,7 +27,7 @@ class PackageInteractiveSelector(object):
         # Compile --skip patterns upfront; plain names match exactly, regex patterns
         # must also match the full name (use '.*django.*' to match substrings).
         skip_patterns = []
-        for s in (options.get('--skip') or []):
+        for s in options.get('--skip') or []:
             pat = s.lower().strip()
             try:
                 skip_patterns.append(re.compile(pat))


### PR DESCRIPTION
Fixes issues found in AI review of #76.

## Changes

- **Exact-name matching**: `--skip django` now skips only `django`, not `django-rest-auth`, `django-cors-headers`, etc. Previously `re.search` matched anywhere in the name. Now uses `re.fullmatch` — plain names match exactly, regex patterns must cover the full name (use `.*django.*` for substring matching).
- **Remove redundant `fullmatch or search`**: `re.search` was dead code after `fullmatch` (search is a superset). Replaced with a single `compiled.fullmatch()` call.
- **Invalid regex error handling**: Patterns are compiled upfront with `re.compile`. A malformed pattern (e.g. `--skip '['`) now raises a clear `SystemExit` message instead of crashing with a raw `re.error`.

## Behaviour

```
--skip django         → skips django only
--skip '.*django.*'   → skips django, django-rest-auth, django-cors-headers, ...
--skip '[invalid'     → exits with: Invalid --skip pattern '[invalid': unterminated character set
```